### PR TITLE
Refactor visualization

### DIFF
--- a/sample-tuatara.toml
+++ b/sample-tuatara.toml
@@ -16,5 +16,5 @@ charset = 'ascii'
 # Pre-caca art image adjustments
 brightness_adj = 0.75
 contrast_adj = 1.25
-# Visualizartion plugin
+# Visualization plugin. Set to 'none' to disable visualization.
 visualization = 'synaescope'

--- a/tuatara/image_utils.py
+++ b/tuatara/image_utils.py
@@ -56,6 +56,8 @@ def image_from_buffer(buffer):
 
 
 def image_from_pixbuf(pixbuf):
+    if not pixbuf:
+        return None
     data = pixbuf.get_pixels()
     mode = "RGB"
     if pixbuf.props.has_alpha is True:

--- a/tuatara/main.py
+++ b/tuatara/main.py
@@ -93,7 +93,6 @@ def main():
     player.set_playlist(playlist)
 
     interface = Interface()
-    player.set_interface(interface)
 
     player.cue_from_playlist()
     loop = GLib.MainLoop()

--- a/tuatara/player.py
+++ b/tuatara/player.py
@@ -15,10 +15,11 @@ import gi
 gi.require_version("Gst", "1.0")
 from gi.repository import Gst  # noqa: E402
 
+GST_PLAY_FLAG_VIS = 1 << 3
+
 
 class Player:
     def __init__(self):
-        GST_PLAY_FLAG_VIS = 1 << 3
         Gst.init()
         self.playlist = []
         self.player = Gst.ElementFactory.make("playbin", "player")
@@ -63,6 +64,9 @@ class Player:
     def seek_forward(self):
         (set, track_pos) = self.player.query_position(Gst.Format.TIME)
         new_pos = track_pos + 10 * Gst.SECOND
+        flags = self.player.get_property("flags")
+        flags ^= GST_PLAY_FLAG_VIS
+        self.player.set_property("flags", flags)
         self.player.seek(
             1.0,
             Gst.Format.TIME,
@@ -72,12 +76,19 @@ class Player:
             Gst.SeekType.NONE,
             0,
         )
+        self.player.get_state(Gst.CLOCK_TIME_NONE)
+        flags = self.player.get_property("flags")
+        flags |= GST_PLAY_FLAG_VIS
+        self.player.set_property("flags", flags)
 
     def seek_reverse(self):
         (set, track_pos) = self.player.query_position(Gst.Format.TIME)
         new_pos = track_pos - 10 * Gst.SECOND
         if new_pos < 0:
             new_pos = 0
+        flags = self.player.get_property("flags")
+        flags ^= GST_PLAY_FLAG_VIS
+        self.player.set_property("flags", flags)
         self.player.seek(
             1.0,
             Gst.Format.TIME,
@@ -87,6 +98,10 @@ class Player:
             Gst.SeekType.NONE,
             0,
         )
+        self.player.get_state(Gst.CLOCK_TIME_NONE)
+        flags = self.player.get_property("flags")
+        flags |= GST_PLAY_FLAG_VIS
+        self.player.set_property("flags", flags)
 
     def clear_current_track(self):
         self.current_track = None


### PR DESCRIPTION
Run it all the time for smoother transitions, but don't spam the bus with pixbuf messages. (Overall this will use more CPU).

Disable visualization around seeking, there's a bug somewhere that can stall the pipeline.