### PR TITLE
Packaging cleanups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,16 @@ name = "tuatara"
 version = "0.5.0"
 description = "Tuatara is a text-mode music player."
 authors = ["Bill Nottingham <notting@splat.cc>"]
-license = "GPL-3.0+"
+license = "GPL-3.0-or-later"
 readme = "README.md"
+repository = "https://github.com/wenottingham/tuatara"
+keywords = ["music", "media", "player"]
 packages = [ { include = "tuatara" } ]
-include = ["sample-tuatara.toml"]
+include = ["sample-tuatara.toml", "MANUAL.md"]
+classifiers = [
+    "Topic :: Multimedia :: Sound/Audio :: Players",
+    "Topic :: Multimedia :: Sound/Audio :: Players :: MP3",
+]
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.13"

--- a/tuatara/cover_art.py
+++ b/tuatara/cover_art.py
@@ -2,7 +2,7 @@
 #
 # SPDX-FileCopyrightText: Copyright © 2023 Bill Nottingham <notting@splat.cc>
 #
-# SPDX-License-Identifier: GPL-3.0+
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 from tuatara.image_utils import (

--- a/tuatara/cover_art_fetcher.py
+++ b/tuatara/cover_art_fetcher.py
@@ -2,7 +2,7 @@
 #
 # SPDX-FileCopyrightText: Copyright © 2023 Bill Nottingham <notting@splat.cc>
 #
-# SPDX-License-Identifier: GPL-3.0+
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import json

--- a/tuatara/image_utils.py
+++ b/tuatara/image_utils.py
@@ -2,7 +2,7 @@
 #
 # SPDX-FileCopyrightText: Copyright © 2023 Bill Nottingham <notting@splat.cc>
 #
-# SPDX-License-Identifier: GPL-3.0+
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import io

--- a/tuatara/interface.py
+++ b/tuatara/interface.py
@@ -2,7 +2,7 @@
 #
 # SPDX-FileCopyrightText: Copyright © 2023 Bill Nottingham <notting@splat.cc>
 #
-# SPDX-License-Identifier: GPL-3.0+
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/tuatara/main.py
+++ b/tuatara/main.py
@@ -4,7 +4,7 @@
 #
 # SPDX-FileCopyrightText: Copyright © 2023 Bill Nottingham <notting@splat.cc>
 #
-# SPDX-License-Identifier: GPL-3.0+
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import argparse

--- a/tuatara/player.py
+++ b/tuatara/player.py
@@ -2,7 +2,7 @@
 #
 # SPDX-FileCopyrightText: Copyright © 2023 Bill Nottingham <notting@splat.cc>
 #
-# SPDX-License-Identifier: GPL-3.0+
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 from urllib3.util import parse_url

--- a/tuatara/playlist.py
+++ b/tuatara/playlist.py
@@ -2,7 +2,7 @@
 #
 # SPDX-FileCopyrightText: Copyright © 2023 Bill Nottingham <notting@splat.cc>
 #
-# SPDX-License-Identifier: GPL-3.0+
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/tuatara/playlist_entry.py
+++ b/tuatara/playlist_entry.py
@@ -2,7 +2,7 @@
 #
 # SPDX-FileCopyrightText: Copyright © 2023 Bill Nottingham <notting@splat.cc>
 #
-# SPDX-License-Identifier: GPL-3.0+
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os

--- a/tuatara/sanitize.py
+++ b/tuatara/sanitize.py
@@ -2,7 +2,7 @@
 #
 # SPDX-FileCopyrightText: Copyright © 2023 Bill Nottingham <notting@splat.cc>
 #
-# SPDX-License-Identifier: GPL-3.0+
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import re

--- a/tuatara/settings.py
+++ b/tuatara/settings.py
@@ -2,7 +2,7 @@
 #
 # SPDX-FileCopyrightText: Copyright © 2023 Bill Nottingham <notting@splat.cc>
 #
-# SPDX-License-Identifier: GPL-3.0+
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
 
 import os


### PR DESCRIPTION
Package the manual, add some more pyproject.toml metadata, use the non-deprecated license tag.