### PR TITLE
Clean up actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.11
+    - name: Set up Python
       uses: actions/setup-python@v3
       with:
         python-version: "3.13"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,18 +12,13 @@ jobs:
   build:
     name: "Build"
     runs-on: "ubuntu-latest"
-    environment:
-      name: "release"
-    strategy:
-      matrix:
-        python-version: ['3.11']
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{matrix.python-version}}
+    - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: ${{matrix.python-version}}
+        python-version: 3.11
     - name: Install system build deps
       run: |
         sudo apt install libgirepository1.0-dev gir1.2-gstreamer-1.0 libcairo2-dev gir1.2-gdkpixbuf-2.0
@@ -43,10 +38,10 @@ jobs:
     - name: "Upload dists"
       uses: "actions/upload-artifact@v4"
       with:
-        name: "release${{matrix.python-version}}"
+        name: "release"
         path: "dist/"
         if-no-files-found: error
-        retention-days: 5
+        retention-days: 1
 
   publish:
     name: "Publish"
@@ -62,7 +57,7 @@ jobs:
     - name: "Download dists"
       uses: actions/download-artifact@v4
       with:
-        name: "release3.11"
+        name: "release"
         path: "dist/"
 
     - name: "Upload dists to GitHub Release"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,13 +43,14 @@ jobs:
       run: |
         SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) \
         poetry build
+
   sonarqube:
     name: SonarQube
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v4
         env:


### PR DESCRIPTION
- no environment needed for the build process
- no need to retain artifacts that long
- make a comment match reality
- clean up some more python versioning that isn't needed when not building PEX